### PR TITLE
Version upgrades

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ ARG COMMIT
 ARG WORKDIR=/ngen
 
 ARG TROUTE_REPO_URL=https://github.com/NOAA-OWP/t-route.git
-ARG TROUTE_BRANCH=ngen
+ARG TROUTE_BRANCH=master
 ARG TROUTE_COMMIT
 
 #### Default arguments for required dependencies needed during various build stages
@@ -40,7 +40,7 @@ ARG ROCKY_BASE_REQUIRED="sudo bash git"
 #    bzip2 expat expat-devel flex bison udunits2 udunits2-devel"
 
 ARG ROCKY_NGEN_DEPS_REQUIRED="sudo gcc gcc-c++ make cmake tar git gcc-gfortran libgfortran \
-    python3 python3-devel python3-pip \
+    python3 python3-devel python3-pip gdal gdal-devel\
     bzip2 expat expat-devel flex bison udunits2 udunits2-devel zlib-devel"
 # TODO: removed texinfo from list because it couldn't be found; make sure this doesn't lead to issues
 
@@ -321,8 +321,15 @@ RUN cd /tmp/ngen-deps \
     #&& ctest \
     && make install \
     # Install required python dependency packages with Pip \
-    && pip3 install numpy pandas pyyaml bmipy Cython blosc2==2.0.0 netCDF4 wheel packaging \
-    && HDF5_DIR=/usr pip3 install --install-option="\'--hdf5 \${HDF5_DIR}\'" --install-option="\'--jobs=$(nproc) \'"  --no-build-isolation tables \
+    # Except blosc2, since packaged wheels on pypi seem to have some issues, build it ourselves
+    && git clone https://github.com/Blosc/python-blosc2/ \
+    && cd python-blosc2 \
+    && git submodule update --init --recursive \
+    # TODO can checkout a particular tag -- as is you end up wtih a dev version, but it seems to work
+    && python3 -m pip install -r requirements-build.txt \
+    && pip3 install . \
+    && pip3 install numpy pandas pyyaml bmipy Cython netCDF4 wheel packaging \
+    && HDF5_DIR=/usr pip3 install -v --install-option="\'--hdf5 \${HDF5_DIR}\'" --install-option="\'--jobs=$(nproc) \'"  --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \
     && echo "alias pip='pip3'" >> /etc/profile \
@@ -408,21 +415,19 @@ RUN cp -s /usr/bin/python3 /usr/bin/python
 RUN cd ${WORKDIR}/t-route \
     && mkdir wheels \
     && pip3 install -r ./requirements.txt \
-    && pip3 install wheel deprecated dask \
+    && pip3 install wheel deprecated dask pyarrow geopandas
+    RUN export FC=gfortran NETCDF=/usr/include \
     && cd ${WORKDIR}/t-route \
-    && cd ./src/python_routing_v02 \
     && ./compiler.sh \
-    && python3 setup.py bdist_wheel \
+    && cd ./src/troute-network \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../python_framework_v02 \
-    && python3 setup.py bdist_wheel \
+    && cd ../troute-routing \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../nwm_routing \
+    && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../ngen_routing \
-    && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/
+    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 
 
 RUN rm /usr/bin/python
 
@@ -459,11 +464,24 @@ COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/wheels /tmp/t-
 COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.txt /tmp/t-route-requirements.txt
 ENV BOOST_ROOT=${WORKDIR}/boost
 
+USER root
+RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+        chgrp -R ${USER} /usr/local/lib*/python3.* ; \
+        chmod -R g+sw /usr/local/lib*/python3.* ; \
+    fi \
+    && if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ]; then \
+        # These packages install command line tools, which try to go in /usr/local/bin \
+        pip3 install pyarrow pyproj fiona; \
+    fi
+USER ${USER}
+
 RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \
         if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ] ; then \
-            pip3 install /tmp/t-route-wheels/*.whl; pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install /tmp/t-route-wheels/*.whl; \
+            pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install deprecated geopandas ; \
             fi; \
         fi \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,12 +40,14 @@ ARG ROCKY_BASE_REQUIRED="sudo bash git"
 #    bzip2 expat expat-devel flex bison udunits2 udunits2-devel"
 
 ARG ROCKY_NGEN_DEPS_REQUIRED="sudo gcc gcc-c++ make cmake tar git gcc-gfortran libgfortran \
-    python39 python39-devel python39-pip \
+    python3 python3-devel python3-pip \
     bzip2 expat expat-devel flex bison udunits2 udunits2-devel zlib-devel"
 # TODO: removed texinfo from list because it couldn't be found; make sure this doesn't lead to issues
 
 ARG BOOST_VERSION=1.72.0
-ARG MPICH_VERSION="3.2"
+#TODO Try mpich 4.x for native arm build support (https://raw.githubusercontent.com/pmodels/mpich/v4.1.1/CHANGES)
+#mpich 3.2 doesn't work well gfortran 11 it seems, an alignment error crops up, but 3.3.2 seems to work...
+ARG MPICH_VERSION="3.3.2"
 ARG MIN_PYTHON="3.8.0"
 ARG MIN_NUMPY="1.18.0"
 
@@ -82,7 +84,7 @@ ARG BUILD_SLOTH="true"
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for Rocky-Linux-based "base"
-FROM rockylinux:8.5 as rocky-base
+FROM rockylinux:9.1 as rocky-base
 
 #ARG USER=root
 
@@ -90,7 +92,7 @@ ARG ROCKY_BASE_REQUIRED
 
 RUN dnf update -y \
     && dnf install -y 'dnf-command(config-manager)' \
-    && dnf config-manager --set-enabled powertools \
+    && dnf config-manager --set-enabled crb \
     && dnf install -y epel-release \
     && dnf -y install ${ROCKY_BASE_REQUIRED} 
     # Note that adduser -p expects an encrypted/hashed password, so it will ignore a simple password \
@@ -106,7 +108,7 @@ ARG WORKDIR=/ngen
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for downloading Boost
-FROM rockylinux:8.5 AS download_boost
+FROM rockylinux:9.1 AS download_boost
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG BOOST_VERSION
@@ -118,7 +120,7 @@ RUN curl -L -o boost_${BOOST_VERSION//./_}.tar.bz2 https://sourceforge.net/proje
 ################################################################################################################
 ##https://support.hdfgroup.org/ftp/HDF5/releases##############################################################################################################
 ##### Create intermediate Docker build stage for downloading MPICH
-FROM rockylinux:8.5 AS download_mpich
+FROM rockylinux:9.1 AS download_mpich
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG MPICH_VERSION
@@ -129,7 +131,7 @@ RUN curl -o /tmp/mpich-${MPICH_VERSION}.tar.gz https://www.mpich.org/static/down
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for downloading MPICH
-FROM rockylinux:8.5 AS download_hd5
+FROM rockylinux:9.1 AS download_hd5
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG HD5_VERSION
@@ -279,7 +281,8 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && cd /tmp/ngen-deps \
     && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
     && cd mpich-${MPICH_VERSION} \
-    && ./configure ${MPICH_CONFIGURE_OPTIONS} \
+    # mpich3 and gfortran > 10 don't get along...https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91731
+    && FFLAGS="-w -fallow-argument-mismatch -O2" ./configure ${MPICH_CONFIGURE_OPTIONS} \
     && make -j $(nproc) ${MPICH_MAKE_OPTIONS} && make install \
     ##### Build and install HDF5 \
     && cd /tmp/ngen-deps \
@@ -579,7 +582,7 @@ ENV PATH=${WORKDIR}:$PATH
 
 ################################################################################################################
 ##### Final stage for image
-FROM rockylinux:8.6-minimal
+FROM rockylinux:9.1-minimal
 
 ########################################Copy over the NGEN artifacts############################################
 COPY --chown=root --from=rocky_build_staging /dmod/ /dmod/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -475,6 +475,27 @@ RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
     fi
 USER ${USER}
 
+#These patches are from ngen commit 7551590a415b89026559c1c570d4154e4746161b
+#and are needed to fix an I/O bug in the sub modules (and bmi tests) that cause an infinite loop
+#the fix_tests patch cleans up some path handling to allow ctest to run automatically and detect
+#and run all tests (822 in serial, 828 in parallel -- some of which are duplicated)
+#Once these patches are applied upstream, this can be removed.
+COPY fix_tests_7551590a415b89026559c1c570d4154e4746161b.patch ${WORKDIR}/ngen/fix_tests.patch
+COPY fix_io_sub_7551590a415b89026559c1c570d4154e4746161b.patch ${WORKDIR}/ngen/fix_io_sub.patch
+# FIXME once these patches are all identified with issues/PR's upstream, drop some links in here
+# Apply the IO fix to submodules, once they all get patched/merged, this can be dropped...
+RUN cd ${WORKDIR}/ngen && git apply --reject --whitespace=fix \
+    # --exclude=extern/SoilFreezeThaw/forcing_code/src/bmi_aorc.c \
+    # --exclude=extern/SoilFreezeThaw/forcing_code/src/bmi_pet.c \
+    # --exclude=extern/cfe/forcing_code/src/bmi_aorc.c \
+    # --exclude=extern/cfe/forcing_code/src/bmi_pet.c \
+    # --exclude=extern/cfe/src/bmi_cfe.c \
+    # --exclude=extern/evapotranspiration/forcing_code/src/bmi_aorc.c \
+    # --exclude=extern/evapotranspiration/src/bmi_pet.c \
+    fix_io_sub.patch && \
+    #apply the patch to the main code
+    git apply --reject --whitespace=fix fix_tests.patch
+
 RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,8 +63,6 @@ ARG FFLAGS="-w -fallow-argument-mismatch -O2"
 ARG MPICH_CONFIGURE_OPTIONS=""
 ARG MPICH_MAKE_OPTIONS
 
-ARG BUILD_PARALLEL_JOBS
-
 ARG NGEN_ACTIVATE_C="ON"
 ARG NGEN_ACTIVATE_FORTRAN="ON"
 ARG NGEN_ACTIVATE_PYTHON="ON"
@@ -408,7 +406,6 @@ FROM rocky-ngen-deps as rocky_build_troute
 ARG REPO_URL
 ARG BRANCH
 ARG COMMIT
-ARG BUILD_PARALLEL_JOBS
 
 COPY --chown=root --from=rocky_init_troute_repo ${WORKDIR}/t-route ${WORKDIR}/t-route
 
@@ -442,7 +439,6 @@ FROM rocky-ngen-deps as rocky_build_ngen
 ARG REPO_URL
 ARG BRANCH
 ARG COMMIT
-ARG BUILD_PARALLEL_JOBS
 
 ARG NGEN_BUILD_CONFIG_TYPE
 ARG NGEN_ACTIVATE_C
@@ -561,8 +557,8 @@ RUN cd ${WORKDIR}/ngen \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
             ./build_sub extern/test_bmi_fortran; \
         fi \
-    && for BUILD_DIR in $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; fi) $(if [ "${BUILD_NGEN_SERIAL}" == "true" ]; then echo "cmake_build_serial"; fi) ; do \
-        cmake --build $BUILD_DIR --target all -j ${BUILD_PARALLEL_JOBS}; \
+    &&  for BUILD_DIR in $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; fi) $(if [ "${BUILD_NGEN_SERIAL}" == "true" ]; then echo "cmake_build_serial"; fi) ; do \
+        cmake --build $BUILD_DIR --target all -j $(nproc); \
     done \
     # run the serial tests \
     && cd ${WORKDIR}/ngen && cmake --build cmake_build_serial --target test \ 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -329,7 +329,7 @@ RUN cd /tmp/ngen-deps \
     && python3 -m pip install -r requirements-build.txt \
     && pip3 install . \
     && pip3 install numpy pandas pyyaml bmipy Cython netCDF4 wheel packaging \
-    && HDF5_DIR=/usr pip3 install -v --install-option="\'--hdf5 \${HDF5_DIR}\'" --install-option="\'--jobs=$(nproc) \'"  --no-build-isolation tables \
+    && HDF5_DIR=/usr pip3 install -v --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \
     && echo "alias pip='pip3'" >> /etc/profile \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ ARG NETCDF_C_VERSION=4.8.1
 ARG NETCDF_CXX_VERSION=4.3.1
 ARG NETCDF_FORTRAN_VERSION=4.6.0
 ARG HD5_VERSION=1.10.9
+ARG BLOSC2_VERSION=v2.2.0
 
 # Work around Fortran MPI issue
 ARG FCFLAGS="-w -fallow-argument-mismatch -O2"
@@ -307,9 +308,9 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && export NCDIR=/usr NFDIR=/usr \
     && LD_LIBRARY_PATH=/usr/lib CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=/usr \
     && make -j $(nproc) \ 
-    && make install
+    && make install \
     ##### Build and install NetCDF C++ 
-RUN cd /tmp/ngen-deps \
+    && cd /tmp/ngen-deps \
     && mkdir netcdf-cxx4 \
     && tar -xzf netcdf-cxx4-${NETCDF_CXX_VERSION}.tar.gz -C netcdf-cxx4 --strip 1 \
     && mkdir netcdf-cxx4/build \
@@ -322,10 +323,12 @@ RUN cd /tmp/ngen-deps \
     && make install \
     # Install required python dependency packages with Pip \
     # Except blosc2, since packaged wheels on pypi seem to have some issues, build it ourselves
+    && cd /tmp/ngen-deps \
     && git clone https://github.com/Blosc/python-blosc2/ \
     && cd python-blosc2 \
+    #checkout a release tag
+    && git checkout ${BLOSC2_VERSION} \ 
     && git submodule update --init --recursive \
-    # TODO can checkout a particular tag -- as is you end up wtih a dev version, but it seems to work
     && python3 -m pip install -r requirements-build.txt \
     && pip3 install . \
     && pip3 install numpy pandas pyyaml bmipy Cython netCDF4 wheel packaging \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -548,39 +548,31 @@ RUN cd ${WORKDIR}/ngen \
         -DNETCDF_CXX_LIBRARY=/usr/local/lib64/libnetcdf-cxx4.so ; \
     fi \
     && ln -s $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; else echo "cmake_build_serial"; fi) cmake_build \
-    &&  if [ "${BUILD_NGEN_PARTITIONER}" == "true" ]; then \
-            cmake --build cmake_build --target partitionGenerator; \
-#            $BUILD_DIR/test/test_bmi_python; \
+    # Build the required submodules/external libs needed for running the tests later \
+    # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib (also needed for test_bmi_multi) \
+    && ./build_sub extern/test_bmi_cpp \
+    # For the external language BMI integrations, conditionally build the test packages/libraries and run tests \
+    &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
+            ./build_sub extern/test_bmi_c; \
+        fi \
+    &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
+            ./build_sub extern/test_bmi_fortran; \
         fi \
     && for BUILD_DIR in $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; fi) $(if [ "${BUILD_NGEN_SERIAL}" == "true" ]; then echo "cmake_build_serial"; fi) ; do \
-        cmake --build $BUILD_DIR --target ngen -j ${BUILD_PARALLEL_JOBS} \
-        #Run the tests, if they fail, the image build fails \
-        && cmake --build $BUILD_DIR --target test_unit -j ${BUILD_PARALLEL_JOBS} \
-        && $BUILD_DIR/test/test_unit \
-        # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib (also needed for test_bmi_multi) \
-        && ./build_sub extern/test_bmi_cpp \
-        && cmake --build $BUILD_DIR --target test_bmi_cpp \
-        && $BUILD_DIR/test/test_bmi_cpp \
-        # For the external language BMI integrations, conditionally build the test packages/libraries and run tests \
-        &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
-                ./build_sub extern/test_bmi_c; \
-                cmake --build $BUILD_DIR --target test_bmi_c; \
-                $BUILD_DIR/test/test_bmi_c; \
-            fi \
-        &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
-                ./build_sub extern/test_bmi_fortran; \
-                cmake --build $BUILD_DIR --target test_bmi_fortran; \
-                $BUILD_DIR/test/test_bmi_fortran; \
-            fi \
-        &&  if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
-                cmake --build $BUILD_DIR --target test_bmi_python; \
-                $BUILD_DIR/test/test_bmi_python; \
-            fi \
-        &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ] && [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ] && [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
-                cmake --build $BUILD_DIR --target test_bmi_multi; \
-                $BUILD_DIR/test/test_bmi_multi; \
-            fi \
+        cmake --build $BUILD_DIR --target all -j ${BUILD_PARALLEL_JOBS}; \
     done \
+    # run the serial tests \
+    && cd ${WORKDIR}/ngen && cmake --build cmake_build_serial --target test \ 
+    # have to remove the output from the previous tests runs for routing test to be run again... \
+    && rm -f ./test/data/routing/*.parquet \
+    # run the parallel tests \
+    && cmake --build cmake_build_parallel --target test \
+    # clean these up again... \
+    && rm -f ./test/data/routing/*.parquet \
+    #Run the MPI tests manually, they don't play well with ctest and are skipped in the above tests \
+    && mpirun -n 2 cmake_build_parallel/test/test_remote_nexus \
+    && mpirun -n 3 cmake_build_parallel/test/test_remote_nexus \
+    && mpirun -n 4 cmake_build_parallel/test/test_remote_nexus \
     && find cmake_build* -type f -name "*" ! \( -name "*.so" -o -name "ngen" -o -name "partitionGenerator" \) -exec rm {} + 
 
 ################################################################################################################

--- a/docker/fix_io_sub_7551590a415b89026559c1c570d4154e4746161b.patch
+++ b/docker/fix_io_sub_7551590a415b89026559c1c570d4154e4746161b.patch
@@ -1,0 +1,119 @@
+diff --git a/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_aorc.c b/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_aorc.c
+index 059cf87..bd22f1e 100644
+--- a/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_aorc.c
++++ b/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_aorc.c
+@@ -480,7 +480,11 @@ int read_file_line_counts_aorc(const char* file_name, int* line_count, int* max_
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_pet.c b/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_pet.c
+index 0b74edf..279f054 100644
+--- a/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_pet.c
++++ b/extern/SoilFreezeThaw/SoilFreezeThaw/forcing_code/src/bmi_pet.c
+@@ -497,7 +497,11 @@ int read_file_line_counts_pet(const char* file_name, int* line_count, int* max_l
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/cfe/cfe/forcing_code/src/bmi_aorc.c b/extern/cfe/cfe/forcing_code/src/bmi_aorc.c
+index 059cf87..bd22f1e 100644
+--- a/extern/cfe/cfe/forcing_code/src/bmi_aorc.c
++++ b/extern/cfe/cfe/forcing_code/src/bmi_aorc.c
+@@ -480,7 +480,11 @@ int read_file_line_counts_aorc(const char* file_name, int* line_count, int* max_
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/cfe/cfe/forcing_code/src/bmi_pet.c b/extern/cfe/cfe/forcing_code/src/bmi_pet.c
+index 9683115..ce2b486 100644
+--- a/extern/cfe/cfe/forcing_code/src/bmi_pet.c
++++ b/extern/cfe/cfe/forcing_code/src/bmi_pet.c
+@@ -497,7 +497,11 @@ int read_file_line_counts_pet(const char* file_name, int* line_count, int* max_l
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/cfe/cfe/src/bmi_cfe.c b/extern/cfe/cfe/src/bmi_cfe.c
+index b85421e..29e8b7e 100644
+--- a/extern/cfe/cfe/src/bmi_cfe.c
++++ b/extern/cfe/cfe/src/bmi_cfe.c
+@@ -2814,7 +2814,11 @@ int read_file_line_counts_cfe(const char* file_name, int* line_count, int* max_l
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/evapotranspiration/evapotranspiration/forcing_code/src/bmi_aorc.c b/extern/evapotranspiration/evapotranspiration/forcing_code/src/bmi_aorc.c
+index 8724829..f924c5d 100644
+--- a/extern/evapotranspiration/evapotranspiration/forcing_code/src/bmi_aorc.c
++++ b/extern/evapotranspiration/evapotranspiration/forcing_code/src/bmi_aorc.c
+@@ -480,7 +480,11 @@ int read_file_line_counts_aorc(const char* file_name, int* line_count, int* max_
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c b/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c
+index 9c72840..4d215ed 100644
+--- a/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c
++++ b/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c
+@@ -510,7 +510,11 @@ int read_file_line_counts_pet(const char* file_name, int* line_count, int* max_l
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')

--- a/docker/fix_tests_7551590a415b89026559c1c570d4154e4746161b.patch
+++ b/docker/fix_tests_7551590a415b89026559c1c570d4154e4746161b.patch
@@ -1,0 +1,196 @@
+diff --git a/extern/test_bmi_c/src/bmi_test_bmi_c.c b/extern/test_bmi_c/src/bmi_test_bmi_c.c
+index 71e11c62e..47bf4e6a2 100644
+--- a/extern/test_bmi_c/src/bmi_test_bmi_c.c
++++ b/extern/test_bmi_c/src/bmi_test_bmi_c.c
+@@ -729,7 +729,11 @@ int read_file_line_counts(const char* file_name, int* line_count, int* max_line_
+         return -1;
+     }
+     int seen_non_whitespace = 0;
+-    char c;
++    int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+         // keep track if this line has seen any char other than space or tab
+         if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+index de19b9e86..c371879e4 100644
+--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
++++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+@@ -426,7 +426,11 @@ void TestBmiCpp::read_file_line_counts(std::string file_name, int* line_count, i
+     throw std::runtime_error("Configuration file does not exist." SOURCE_LOC);
+   }
+   int seen_non_whitespace = 0;
+-  char c;
++  int c; //EOF is a negative constant...and char may be either signed OR unsigned
++         //depending on the compiler, system, achitectured, ect.  So there are cases
++         //where this loop could go infinite comparing EOF to unsigned char
++         //the return of fgetc is int, and should be stored as such!
++         //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
+   for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
+     // keep track if this line has seen any char other than space or tab
+     if (c != ' ' && c != '\t' && c != '\n')
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 78b7e0920..722da840d 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -285,6 +285,7 @@ if(NGEN_ACTIVATE_ROUTING)
+             test_routing_pybind
+             1
+             routing/Routing_Py_Bind_Test.cpp
++            NGen::core # for filechecker utility
+             NGen::routing
+             pybind11::embed
+     )
+diff --git a/test/core/nexus/NexusRemoteTests.cpp b/test/core/nexus/NexusRemoteTests.cpp
+index 524b7da05..2e9e48693 100644
+--- a/test/core/nexus/NexusRemoteTests.cpp
++++ b/test/core/nexus/NexusRemoteTests.cpp
+@@ -68,6 +68,11 @@ void Nexus_Remote_Test::TearDown()
+ //to a downstream remote nexus.
+ TEST_F(Nexus_Remote_Test, TestInit0)
+ {
++    if ( mpi_num_procs < 2 )
++    {
++    	GTEST_SKIP();
++    }
++
+     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
+ 
+     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
+@@ -409,6 +414,11 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
+ 
+ TEST_F(Nexus_Remote_Test, TestDeadlock1)
+ {
++    if ( mpi_num_procs < 2 )
++    {
++    	GTEST_SKIP();
++    }
++
+     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
+ 
+     std::shared_ptr<HY_PointHydroNexusRemote> nexus1;
+diff --git a/test/data/routing/ngen_routing_config_unit_test.yaml b/test/data/routing/ngen_routing_config_unit_test.yaml
+index 80f4a40ab..a93eaf5c0 100644
+--- a/test/data/routing/ngen_routing_config_unit_test.yaml
++++ b/test/data/routing/ngen_routing_config_unit_test.yaml
+@@ -9,7 +9,7 @@ network_topology_parameters:
+     supernetwork_parameters:
+         #----------
+         geo_file_type: HYFeaturesNetwork 
+-        geo_file_path: ./test/data/routing/gauge_01073000.gpkg 
++        geo_file_path: ../../test/data/routing/gauge_01073000.gpkg
+         mask_file_path: # domain/unit_test_noRS/coastal_subset.txt
+         synthetic_wb_segments:
+             #- 4800002
+@@ -21,8 +21,8 @@ network_topology_parameters:
+         break_network_at_waterbodies: False 
+         level_pool:
+             #----------
+-            level_pool_waterbody_parameter_file_path: ./test/data/routing/gauge_01073000.gpkg 
+-            reservoir_parameter_file                : ./test/data/routing/gauge_01073000.gpkg
++            level_pool_waterbody_parameter_file_path: ../../test/data/routing/gauge_01073000.gpkg
++            reservoir_parameter_file                : ../../test/data/routing/gauge_01073000.gpkg
+         #rfc:
+             #----------
+             #reservoir_parameter_file                : domain/reservoir_index_AnA.nc
+@@ -58,11 +58,11 @@ compute_parameters:
+         #----------
+         qts_subdivisions            : 12
+         dt                          : 300 # [sec]
+-        qlat_input_folder           : ./test/data/routing/ 
++        qlat_input_folder           : ../../test/data/routing/
+         qlat_file_pattern_filter    : "nex-*"
+-        nexus_input_folder          : ./test/data/routing/ 
++        nexus_input_folder          : ../../test/data/routing/
+         nexus_file_pattern_filter   : "nex-*" #OR "*NEXOUT.parquet" OR "nex-*"
+-        binary_nexus_file_folder    : ./test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
++        binary_nexus_file_folder    : ../../test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
+         #coastal_boundary_input_file : channel_forcing/schout_1.nc  
+         nts                         : 8640 #288 for 1day
+         max_loop_size               : 720 # [hr]  
+@@ -98,6 +98,6 @@ output_parameters:
+         #wrf_hydro_channel_output_source_folder: ./
+     chanobs_output:
+         #----------
+-        chanobs_output_directory: ./test/data/routing/ 
++        chanobs_output_directory: ../../test/data/routing/
+         chanobs_filepath        : Chanobs.nc
+-    lakeout_output: ./test/data/routing/
++    lakeout_output: ../../test/data/routing/
+diff --git a/test/realizations/Formulation_Manager_Test.cpp b/test/realizations/Formulation_Manager_Test.cpp
+index 7fff4f9fb..230125faa 100644
+--- a/test/realizations/Formulation_Manager_Test.cpp
++++ b/test/realizations/Formulation_Manager_Test.cpp
+@@ -69,11 +69,12 @@ class Formulation_Manager_Test : public ::testing::Test {
+ 
+     std::vector<std::string> path_options = {
+             "",
++            "../",
++            "../../",
+             "./test/",
+             "../test/",
+-            "../../test/",
+-            "../",
+-            "../../"
++            "../../test/"
++
+     };
+ 
+     std::string fix_paths(std::string json)
+@@ -84,6 +85,17 @@ class Formulation_Manager_Test : public ::testing::Test {
+                 "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
+                 "./data/forcing/cat-27115-nwm-aorc-variant-derived-format.csv"
+         };
++        std::vector<std::string> v = {};
++        for(unsigned int i = 0; i < path_options.size(); i++){
++                v.push_back( path_options[i] + "data/forcing" );
++        }
++        std::string dir = utils::FileChecker::find_first_readable(v);
++        if(dir != ""){
++                std::string remove = "\"./data/forcing/\"";
++                std::string replace = "\""+dir+"\"";
++                //std::cerr<<"TRYING TO REPLACE DIRECTORY... "<<remove<<" -> "<<replace<<std::endl;
++                boost::replace_all(json, remove , replace);
++        }
+         for (unsigned int i = 0; i < forcing_paths.size(); i++) {
+           if(json.find(forcing_paths[i]) == std::string::npos){
+             continue;
+@@ -95,7 +107,7 @@ class Formulation_Manager_Test : public ::testing::Test {
+           std::string right_path = utils::FileChecker::find_first_readable(v);
+           if(right_path != forcing_paths[i]){
+             std::cerr<<"Replacing "<<forcing_paths[i]<<" with "<<right_path<<std::endl;
+-            json = json.replace(json.find(forcing_paths[i]), forcing_paths[i].length(), right_path);
++            boost::replace_all(json, forcing_paths[i] , right_path);
+           }
+         }
+         return json;
+diff --git a/test/routing/Routing_Py_Bind_Test.cpp b/test/routing/Routing_Py_Bind_Test.cpp
+index 2831368e5..a89da36c9 100644
+--- a/test/routing/Routing_Py_Bind_Test.cpp
++++ b/test/routing/Routing_Py_Bind_Test.cpp
+@@ -1,6 +1,7 @@
+ #ifdef ROUTING_PYBIND_TESTS_ACTIVE
+ #include "gtest/gtest.h"
+ #include "Routing_Py_Adapter.hpp"
++#include "FileChecker.h"
+ #include <string>
+ #include <pybind11/embed.h>
+ #include <pybind11/stl.h>
+@@ -33,8 +34,12 @@ TEST_F(RoutingPyBindTest, TestRoutingPyBind)
+   //std::vector<double> nexus_values_vec{1.1, 2.2, 3.3, 4.4, 5.5};
+ 
+   //SET THESE AS INPUTS
+-  std::string t_route_config_file_with_path = "./test/data/routing/ngen_routing_config_unit_test.yaml";
+-
++  std::vector<std::string> paths = {
++          "./test/data/routing/ngen_routing_config_unit_test.yaml",
++          "../test/data/routing/ngen_routing_config_unit_test.yaml",
++          "../../test/data/routing/ngen_routing_config_unit_test.yaml"
++  };
++  std::string t_route_config_file_with_path = utils::FileChecker::find_first_readable(paths);
+   //Note: Currently, delta_time is set in the t-route yaml configuration file, and the
+   //number_of_timesteps is determined from the total number of nexus outputs in t-rout
+   //It is recommended to still pass these values to the routing_py_adapter object in


### PR DESCRIPTION
This image also builds/runs on arm 64 successfully, so this should allow the cross compiling of x86 and arm images.

These commits do a few things worth noting.

1. Upgrade all rocky image layers to version 9.1
2. Update the t-route build and install to use the current master branch
3. Patches ngen and the used submodules to prevent an infinite loop bug in certain I/O code.
4. Refactors the image build steps to build and run ALL tests for both serial and parallel builds.

Note that in step 4, the tests built and run will automtaically be adjusted based on the build flags/args, and if any test fails, the build will error/fail.

Closes #24 from a technical perspective, ngen parallel should work, but the realization in that issue may need to be debugged with correct library paths?
Closes #25 

Can also close #20